### PR TITLE
Fix APScheduler entry_points compatibility error

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,8 @@
 import os
 import sys
 
+from project import compat  # noqa: F401
+
 
 def main():
     """Run administrative tasks."""

--- a/project/asgi.py
+++ b/project/asgi.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/asgi/
 
 import os
 
+from project import compat  # noqa: F401
 from django.core.asgi import get_asgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')

--- a/project/compat.py
+++ b/project/compat.py
@@ -1,0 +1,52 @@
+"""Compatibility helpers for third-party packages."""
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+
+def _patch_entry_points(module: ModuleType) -> None:
+    entry_points = getattr(module, "entry_points", None)
+    if not callable(entry_points):
+        return
+
+    try:
+        entry_points(group="__compat_test__")
+    except TypeError:
+        original = entry_points
+
+        def _patched_entry_points(*args, **kwargs):
+            kwargs_copy = dict(kwargs)
+            group = kwargs_copy.pop("group", None)
+            name = kwargs_copy.pop("name", None)
+            result = original(*args, **kwargs_copy)
+            if group is None and name is None:
+                return result
+
+            selector = getattr(result, "select", None)
+            if callable(selector):
+                return selector(group=group, name=name)
+
+            filtered = [
+                entry
+                for entry in result
+                if (group is None or getattr(entry, "group", None) == group)
+                and (name is None or getattr(entry, "name", None) == name)
+            ]
+            return type(result)(filtered) if isinstance(result, (list, tuple)) else filtered
+
+        module.entry_points = _patched_entry_points
+
+
+def patch_importlib_entry_points() -> None:
+    for module_name in ("importlib.metadata", "importlib_metadata"):
+        module = sys.modules.get(module_name)
+        if module is None:
+            try:
+                module = __import__(module_name)
+            except ImportError:
+                continue
+        _patch_entry_points(module)
+
+
+patch_importlib_entry_points()

--- a/project/wsgi.py
+++ b/project/wsgi.py
@@ -8,6 +8,8 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
 """
 
 import os
+
+from project import compat  # noqa: F401
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')


### PR DESCRIPTION
## Summary
- add a compatibility shim so importlib.metadata.entry_points accepts the legacy group argument expected by APScheduler
- load the shim from manage.py, wsgi.py, and asgi.py before Django initialises the apps

## Testing
- python manage.py migrate --noinput *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0473ae944832c96047dbf6b9a2a6b