### PR TITLE
Adjust landing page header layout

### DIFF
--- a/home/templates/ar/landing_page.html
+++ b/home/templates/ar/landing_page.html
@@ -113,6 +113,11 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    margin-left: auto;
+  }
+
+  .menu .menu__action + .menu__action {
+    margin-left: 0;
   }
 
   .menu .menu__action .trk-btn {
@@ -133,18 +138,40 @@
     color: #e5cd26;
   }
 
+  .header-section .header-wrapper {
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: nowrap;
+  }
+
+  .header-section .logo {
+    display: flex;
+    align-items: center;
+  }
+
   .header-section .menu-area {
     position: relative;
     flex-wrap: nowrap;
-    gap: 0.75rem;
+    gap: 1.5rem;
+    flex: 1 1 auto;
+    justify-content: center;
+    align-items: center;
   }
 
   .header-section .menu-area .menu {
     flex: 1 1 auto;
+    justify-content: center;
+    gap: 1.5rem;
+    margin: 0;
+  }
+
+  .header-section .menu-area .menu > li {
+    display: flex;
+    align-items: center;
   }
 
   .header-section .menu-area .header-bar {
-    margin-inline-start: auto;
+    margin-inline-start: 0;
     display: inline-flex;
     flex-direction: column;
     justify-content: space-between;
@@ -152,28 +179,34 @@
 
   .menu .menu__action--rtl {
     flex-direction: row-reverse;
+    margin-left: 0;
+    margin-right: auto;
+  }
+
+  .menu .menu__action--rtl + .menu__action--rtl {
+    margin-right: 0;
   }
 
   @media (max-width: 991.98px) {
     .header-section .header-wrapper {
-      flex-direction: column;
-      gap: 1rem;
-    }
-
-    .header-section .menu-area {
-      width: 100%;
-      justify-content: flex-end;
-    }
-
-    .header-section .menu {
-      flex-direction: column;
-      align-items: center;
+      flex-wrap: nowrap;
       gap: 0.75rem;
     }
 
+    .header-section .menu-area {
+      flex: 1 1 auto;
+      justify-content: space-between;
+      gap: 0.75rem;
+    }
+
+    .header-section .menu-area .menu {
+      flex: 1 1 auto;
+      justify-content: flex-start;
+      gap: 1rem;
+    }
+
     .menu .menu__action {
-      width: 100%;
-      justify-content: center;
+      margin-left: auto;
     }
 
     .banner__content {
@@ -261,8 +294,8 @@
     <!-- Navbar -->
     <header class="header-section header-section--style1">
         <div class="header-bottom">
-          <div style="">
-            <div class="header-wrapper" style="justify-content: space-evenly;display: flex;">
+          <div>
+            <div class="header-wrapper">
               <div class="logo">
                 <a href="#">
                   <img class="" style="width:130px;" src="{% static 'assets/images/logo/preloader.png' %}" alt="logo">
@@ -286,7 +319,7 @@
                   <li>
                     <a href="#contactsection" class="menu-li-a">تواصل معنا</a>
                   </li>
-                  <li class="menu__action">
+                  <li class="menu__action menu__action--rtl">
                     <a href="{% url 'accounts:login_ar' %}" class="trk-btn trk-btn--border trk-btn--primary">
                       <span>تسجيل دخول</span>
                     </a>

--- a/home/templates/landing_page.html
+++ b/home/templates/landing_page.html
@@ -113,6 +113,11 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    margin-left: auto;
+  }
+
+  .menu .menu__action + .menu__action {
+    margin-left: 0;
   }
 
   .menu .menu__action .trk-btn {
@@ -133,18 +138,40 @@
     color: #e5cd26;
   }
 
+  .header-section .header-wrapper {
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: nowrap;
+  }
+
+  .header-section .logo {
+    display: flex;
+    align-items: center;
+  }
+
   .header-section .menu-area {
     position: relative;
     flex-wrap: nowrap;
-    gap: 0.75rem;
+    gap: 1.5rem;
+    flex: 1 1 auto;
+    justify-content: center;
+    align-items: center;
   }
 
   .header-section .menu-area .menu {
     flex: 1 1 auto;
+    justify-content: center;
+    gap: 1.5rem;
+    margin: 0;
+  }
+
+  .header-section .menu-area .menu > li {
+    display: flex;
+    align-items: center;
   }
 
   .header-section .menu-area .header-bar {
-    margin-inline-start: auto;
+    margin-inline-start: 0;
     display: inline-flex;
     flex-direction: column;
     justify-content: space-between;
@@ -152,24 +179,24 @@
 
   @media (max-width: 991.98px) {
     .header-section .header-wrapper {
-      flex-direction: column;
-      gap: 1rem;
-    }
-
-    .header-section .menu-area {
-      width: 100%;
-      justify-content: flex-end;
-    }
-
-    .header-section .menu {
-      flex-direction: column;
-      align-items: center;
+      flex-wrap: nowrap;
       gap: 0.75rem;
     }
 
+    .header-section .menu-area {
+      flex: 1 1 auto;
+      justify-content: space-between;
+      gap: 0.75rem;
+    }
+
+    .header-section .menu-area .menu {
+      flex: 1 1 auto;
+      justify-content: flex-start;
+      gap: 1rem;
+    }
+
     .menu .menu__action {
-      width: 100%;
-      justify-content: center;
+      margin-left: auto;
     }
 
     .banner__content {
@@ -257,8 +284,8 @@
     <!-- Navbar -->
     <header class="header-section header-section--style1">
         <div class="header-bottom">
-          <div style="">
-            <div class="header-wrapper" style="justify-content: space-evenly;display: flex;">
+          <div>
+            <div class="header-wrapper">
               <div class="logo">
                 <a href="#">
                   <img class="" style="width:130px;" src="{% static 'assets/images/logo/preloader.png' %}" alt="logo">


### PR DESCRIPTION
## Summary
- center the navigation menu between the logo and account controls on the English landing page header
- apply the same header alignment tweaks to the Arabic landing page with RTL-specific spacing fixes
- tune mobile breakpoints so the hamburger icon stays aligned with the menu actions

## Testing
- python manage.py check *(fails: Django not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c68b3e30832cb2a481881ca66aa0