### PR TITLE
Align mobile hamburger opposite logo

### DIFF
--- a/home/templates/ar/landing_page.html
+++ b/home/templates/ar/landing_page.html
@@ -191,10 +191,14 @@
     .header-section .header-wrapper {
       flex-wrap: nowrap;
       gap: 0.75rem;
+      align-items: center;
     }
 
     .header-section .menu-area {
       flex: 1 1 auto;
+      flex-wrap: nowrap;
+      flex-direction: row-reverse;
+      align-items: center;
       justify-content: space-between;
       gap: 0.75rem;
     }
@@ -203,6 +207,11 @@
       flex: 1 1 auto;
       justify-content: flex-start;
       gap: 1rem;
+    }
+
+    .header-section .menu-area .header-bar {
+      margin-right: auto;
+      margin-left: 0;
     }
 
     .menu .menu__action {

--- a/home/templates/landing_page.html
+++ b/home/templates/landing_page.html
@@ -181,10 +181,13 @@
     .header-section .header-wrapper {
       flex-wrap: nowrap;
       gap: 0.75rem;
+      align-items: center;
     }
 
     .header-section .menu-area {
       flex: 1 1 auto;
+      flex-wrap: nowrap;
+      align-items: center;
       justify-content: space-between;
       gap: 0.75rem;
     }
@@ -193,6 +196,11 @@
       flex: 1 1 auto;
       justify-content: flex-start;
       gap: 1rem;
+    }
+
+    .header-section .menu-area .header-bar {
+      margin-left: auto;
+      margin-right: 0;
     }
 
     .menu .menu__action {


### PR DESCRIPTION
## Summary
- keep the hamburger icon aligned with the opposite side of the logo on the English landing page header for mobile breakpoints
- mirror the mobile header alignment for the Arabic landing page so the hamburger slides to the far left while the logo stays on the right

## Testing
- python -m compileall home landing_page

------
https://chatgpt.com/codex/tasks/task_e_68d1ca53a938832cbae3e10e54416be3