### PR TITLE
Fix partner counters to skip expired users

### DIFF
--- a/home/templates/ar/profile.html
+++ b/home/templates/ar/profile.html
@@ -209,7 +209,7 @@
                 <i class="fas fa-user-plus" style="margin: 5px; color: #00d094"></i>
 
                 <span style="color:white">الشركاء المباشرون :</span>
-                <p>{{users.count}}  </p>
+                <p>{{direct_partners_count}}  </p>
               </div>
               <div class="d-flex">
                 <i class="fas fa-users" style="margin: 5px; color: #00d094"></i>

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -162,7 +162,7 @@
                 <i class="fas fa-user-plus" style="margin: 5px; color: #00d094"></i>
 
                 <span style="color:white">direct partener :</span>
-                <p>{{users.count}}</p>
+                <p>{{direct_partners_count}}</p>
               </div>
               <div class="d-flex">
                 <i class="fas fa-users" style="margin: 5px; color: #00d094"></i>


### PR DESCRIPTION
## Summary
- update partner aggregation logic to skip expired accounts while still traversing their downlines
- expose the active direct partner count in profile contexts and templates so counters show non-expired members only

## Testing
- python manage.py test accounts *(fails: Django not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d41f787c832caee934b85d876a51