### PR TITLE
Add English-prefixed landing page routes

### DIFF
--- a/landing_page/urls.py
+++ b/landing_page/urls.py
@@ -4,15 +4,18 @@ from django.urls import path
 app_name = 'landing_page'
 urlpatterns = [
     path('', views.LandingPage, name='LandingPage'),
+    path('en/', views.LandingPage, name='LandingPage'),
     path('update_requests/', views.update_requests, name='update_requests'),
     path('userlandingpage/', views.UserLandingPagedef, name='UserLandingPage'),
+    path('en/userlandingpage', views.UserLandingPagedef, name='UserLandingPage'),
     path('page/<str:pagename>', views.outuserlandingpage, name='outuserlandingpage'),
-    
+    path('page/en/<str:pagename>', views.outuserlandingpage, name='outuserlandingpage'),
+
     #-----------------ar-----------------------
     path('ar/', views.LandingPage_ar, name='LandingPage_ar'),
     path('ar/userlandingpage', views.UserLandingPagedef_ar, name='UserLandingPage_ar'),
     path('page/ar/<str:pagename>', views.outuserlandingpage_ar, name='outuserlandingpage_ar'),
-    
-    
-    
+
+
+
 ]


### PR DESCRIPTION
## Summary
- add English-prefixed routes for the landing page root and user view
- mirror English page URL pattern to cover /landingpage/en paths

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d1e179b678832cab29e6abca8685ae