### PR TITLE
Fix copy link button on user landing page

### DIFF
--- a/home/templates/ar/inneruserlandingpage.html
+++ b/home/templates/ar/inneruserlandingpage.html
@@ -4,6 +4,11 @@
 {% load static %}
 <!---block django-->
 {% block body %}
+    <style>
+        #copypagelink {
+            cursor: pointer;
+        }
+    </style>
     <!-- Request Plan Section -->
     <div class="container my-5">
         <div style="display: flex; justify-content: space-between; align-items: center">
@@ -173,24 +178,72 @@ $(document).ready(function() {
 
 
     <script>
-        document.getElementById('copypagelink').addEventListener('click', function() {
-            // Get the link from the hidden anchor tag
-            const link = document.getElementById('pagelink').href;
-    
-            // Copy the link to the clipboard
-            navigator.clipboard.writeText(link).then(function() {
-                // Display success message
-                const message = document.getElementById('copy-message');
+        (function () {
+            const copyTrigger = document.getElementById('copypagelink');
+            const linkElement = document.getElementById('pagelink');
+            const message = document.getElementById('copy-message');
+            const defaultMessage = message ? message.textContent : '';
+            const defaultColor = message ? message.style.color : '';
+
+            if (!copyTrigger || !linkElement) {
+                return;
+            }
+
+            const showMessage = (text, color) => {
+                if (!message) {
+                    return;
+                }
+
+                message.textContent = text;
                 message.style.display = 'block';
-                
-                // Hide the message after 2 seconds
+
+                if (color) {
+                    message.style.color = color;
+                }
+
                 setTimeout(() => {
                     message.style.display = 'none';
+                    message.textContent = defaultMessage;
+                    message.style.color = defaultColor;
                 }, 2000);
-            }, function(err) {
-                console.error('Error copying text: ', err);
+            };
+
+            const copyText = async (text) => {
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    await navigator.clipboard.writeText(text);
+                    return;
+                }
+
+                const helper = document.createElement('textarea');
+                helper.value = text;
+                helper.setAttribute('readonly', '');
+                helper.style.position = 'absolute';
+                helper.style.left = '-9999px';
+                document.body.appendChild(helper);
+                helper.select();
+
+                const successful = document.execCommand('copy');
+                document.body.removeChild(helper);
+
+                if (!successful) {
+                    throw new Error('Fallback copy command was unsuccessful');
+                }
+            };
+
+            copyTrigger.addEventListener('click', async (event) => {
+                event.preventDefault();
+
+                const linkToCopy = linkElement.href;
+
+                try {
+                    await copyText(linkToCopy);
+                    showMessage(defaultMessage, '#198754');
+                } catch (error) {
+                    console.error('Error copying text: ', error);
+                    showMessage('تعذّر نسخ الرابط، يرجى نسخه يدويًا.', '#dc3545');
+                }
             });
-        });
+        })();
     </script>
 
 

--- a/home/templates/inneruserlandingpage.html
+++ b/home/templates/inneruserlandingpage.html
@@ -4,6 +4,11 @@
 {% load static %}
 <!---block django-->
 {% block body %}
+    <style>
+        #copypagelink {
+            cursor: pointer;
+        }
+    </style>
     <!-- Request Plan Section -->
     <div class="container my-5">
         <div style="display: flex; justify-content: space-between; align-items: center">
@@ -180,24 +185,72 @@ $(document).ready(function() {
 
 
     <script>
-        document.getElementById('copypagelink').addEventListener('click', function() {
-            // Get the link from the hidden anchor tag
-            const link = document.getElementById('pagelink').href;
-    
-            // Copy the link to the clipboard
-            navigator.clipboard.writeText(link).then(function() {
-                // Display success message
-                const message = document.getElementById('copy-message');
+        (function () {
+            const copyTrigger = document.getElementById('copypagelink');
+            const linkElement = document.getElementById('pagelink');
+            const message = document.getElementById('copy-message');
+            const defaultMessage = message ? message.textContent : '';
+            const defaultColor = message ? message.style.color : '';
+
+            if (!copyTrigger || !linkElement) {
+                return;
+            }
+
+            const showMessage = (text, color) => {
+                if (!message) {
+                    return;
+                }
+
+                message.textContent = text;
                 message.style.display = 'block';
-                
-                // Hide the message after 2 seconds
+
+                if (color) {
+                    message.style.color = color;
+                }
+
                 setTimeout(() => {
                     message.style.display = 'none';
+                    message.textContent = defaultMessage;
+                    message.style.color = defaultColor;
                 }, 2000);
-            }, function(err) {
-                console.error('Error copying text: ', err);
+            };
+
+            const copyText = async (text) => {
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    await navigator.clipboard.writeText(text);
+                    return;
+                }
+
+                const helper = document.createElement('textarea');
+                helper.value = text;
+                helper.setAttribute('readonly', '');
+                helper.style.position = 'absolute';
+                helper.style.left = '-9999px';
+                document.body.appendChild(helper);
+                helper.select();
+
+                const successful = document.execCommand('copy');
+                document.body.removeChild(helper);
+
+                if (!successful) {
+                    throw new Error('Fallback copy command was unsuccessful');
+                }
+            };
+
+            copyTrigger.addEventListener('click', async (event) => {
+                event.preventDefault();
+
+                const linkToCopy = linkElement.href;
+
+                try {
+                    await copyText(linkToCopy);
+                    showMessage(defaultMessage, '#198754');
+                } catch (error) {
+                    console.error('Error copying text: ', error);
+                    showMessage('Unable to copy link. Please copy it manually.', '#dc3545');
+                }
             });
-        });
+        })();
     </script>
 
 


### PR DESCRIPTION
## Summary
- ensure the copy link trigger is styled as a clickable element in both landing page editors
- add robust clipboard handling with fallback logic and clearer user feedback for copying in English and Arabic templates

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d26c9c7f5c832cb9f791036aaca67d