### PR TITLE
Enforce membership expiration during authenticated sessions

### DIFF
--- a/accounts/middleware.py
+++ b/accounts/middleware.py
@@ -1,0 +1,27 @@
+from django.contrib import messages
+from django.contrib.auth import logout
+from django.shortcuts import redirect
+from django.utils import timezone
+
+
+class MembershipExpirationMiddleware:
+    """Ensure authenticated users with expired memberships are logged out."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        user = getattr(request, "user", None)
+
+        if user is not None and user.is_authenticated:
+            ended_at = getattr(user, "ended_at", None)
+
+            if ended_at and ended_at < timezone.now():
+                logout(request)
+                messages.error(
+                    request,
+                    "Your plan has ended. Please contact the administrators to renew your plan.",
+                )
+                return redirect("accounts:login")
+
+        return self.get_response(request)

--- a/project/settings.py
+++ b/project/settings.py
@@ -87,6 +87,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'accounts.middleware.MembershipExpirationMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 


### PR DESCRIPTION
## Summary
- add middleware that logs out users whose memberships have expired
- register the middleware so the check runs on every request

## Testing
- `python manage.py check` *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d26ce04cec832cbe97ce7df1b6977c