### PR TITLE
Protect Arabic home view behind login

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -29,6 +29,7 @@ def home(request):
 
 #=====================================AR==========================================
 
+@login_required
 def home_ar(request):
     user = request.user
     user_profile = Profile.objects.get(user=user)


### PR DESCRIPTION
## Summary
- require authentication for the Arabic home view to align with the English version and avoid profile lookup errors

## Testing
- ⚠️ `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d325a038a0832cab3690d94e047d90