### PR TITLE
Handle missing user profiles in home views

### DIFF
--- a/home/templates/ar/profile_missing.html
+++ b/home/templates/ar/profile_missing.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="utf-8">
+  <title>استكمال إعداد الملف الشخصي</title>
+  <style>
+    body {
+      background-color: #081c16;
+      color: #f1f5f9;
+      font-family: "Tajawal", "Cairo", Arial, sans-serif;
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .card {
+      background: rgba(8, 28, 22, 0.85);
+      border: 1px solid #0f3c2f;
+      border-radius: 16px;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+      max-width: 420px;
+      padding: 32px;
+      text-align: center;
+    }
+    h1 {
+      color: #00d094;
+      font-size: 28px;
+      margin-bottom: 16px;
+    }
+    p {
+      line-height: 1.8;
+      margin: 0 0 20px;
+    }
+    a {
+      color: #00d094;
+      font-weight: 600;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>قريبًا ستكون جاهزًا!</h1>
+    <p>لم يتم العثور على ملف شخصي مرتبط بحسابك بعد، وهذا يعني غالبًا أن إجراءات التسجيل لم تكتمل.</p>
+    <p>يرجى التواصل مع إدارة المنصة لاستكمال إعداد ملفك الشخصي ومنحك صلاحية الدخول الكاملة.</p>
+    <p><a href="mailto:support@the-whales.com">التواصل مع الدعم</a></p>
+    <p><a href="{% url 'accounts:logout_ar' %}">تسجيل الخروج</a></p>
+  </main>
+</body>
+</html>

--- a/home/templates/profile_missing.html
+++ b/home/templates/profile_missing.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Profile Setup Required</title>
+  <style>
+    body {
+      background-color: #081c16;
+      color: #f1f5f9;
+      font-family: "Poppins", Arial, sans-serif;
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .card {
+      background: rgba(8, 28, 22, 0.85);
+      border: 1px solid #0f3c2f;
+      border-radius: 16px;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+      max-width: 420px;
+      padding: 32px;
+      text-align: center;
+    }
+    h1 {
+      color: #00d094;
+      font-size: 28px;
+      margin-bottom: 16px;
+    }
+    p {
+      line-height: 1.6;
+      margin: 0 0 20px;
+    }
+    a {
+      color: #00d094;
+      font-weight: 600;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>We're almost ready!</h1>
+    <p>The system couldn't find a profile linked to your account yet. This usually means your onboarding isn't finished.</p>
+    <p>Please contact the platform administrator so they can complete your profile setup and give you full access.</p>
+    <p><a href="mailto:support@the-whales.com">Contact support</a></p>
+    <p><a href="{% url 'accounts:logout' %}">Log out</a></p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a helper that serves a friendly fallback page when a logged-in user does not yet have an associated profile
- protect the Arabic home route with authentication and reuse the helper in the error handlers to avoid crashes
- provide English and Arabic fallback templates instructing users to contact support when their profile is missing

## Testing
- `python manage.py check` *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d323747f2c832c889b90c5a0a3f809