### PR TITLE
Clarify missing profile requirements for onboarding

### DIFF
--- a/home/templates/ar/profile_missing.html
+++ b/home/templates/ar/profile_missing.html
@@ -32,6 +32,19 @@
       line-height: 1.8;
       margin: 0 0 20px;
     }
+    .missing-title {
+      font-weight: 600;
+    }
+    .missing-list {
+      text-align: right;
+      margin: 0 0 20px 0;
+      padding: 0 20px 0 0;
+      line-height: 1.8;
+      list-style-position: inside;
+    }
+    .missing-list li {
+      margin-bottom: 6px;
+    }
     a {
       color: #00d094;
       font-weight: 600;
@@ -46,7 +59,14 @@
   <main class="card">
     <h1>قريبًا ستكون جاهزًا!</h1>
     <p>لم يتم العثور على ملف شخصي مرتبط بحسابك بعد، وهذا يعني غالبًا أن إجراءات التسجيل لم تكتمل.</p>
-    <p>يرجى التواصل مع إدارة المنصة لاستكمال إعداد ملفك الشخصي ومنحك صلاحية الدخول الكاملة.</p>
+    <p class="missing-title">لاستكمال تفعيل حسابك نحتاج إلى البيانات التالية:</p>
+    <ul class="missing-list">
+      <li>خطة الاشتراك المرتبطة بحسابك</li>
+      <li>اسمك الكامل</li>
+      <li>عنوان السكن</li>
+      <li>تاريخ الميلاد (إن وُجد)</li>
+    </ul>
+    <p>يرجى التواصل مع إدارة المنصة وتزويدهم بالبيانات المذكورة أعلاه لاستكمال إعداد ملفك الشخصي ومنحك صلاحية الدخول الكاملة.</p>
     <p><a href="mailto:support@the-whales.com">التواصل مع الدعم</a></p>
     <p><a href="{% url 'accounts:logout_ar' %}">تسجيل الخروج</a></p>
   </main>

--- a/home/templates/profile_missing.html
+++ b/home/templates/profile_missing.html
@@ -32,6 +32,18 @@
       line-height: 1.6;
       margin: 0 0 20px;
     }
+    .missing-title {
+      font-weight: 600;
+    }
+    .missing-list {
+      text-align: left;
+      margin: 0 0 20px 0;
+      padding: 0 0 0 20px;
+      line-height: 1.6;
+    }
+    .missing-list li {
+      margin-bottom: 6px;
+    }
     a {
       color: #00d094;
       font-weight: 600;
@@ -46,7 +58,14 @@
   <main class="card">
     <h1>We're almost ready!</h1>
     <p>The system couldn't find a profile linked to your account yet. This usually means your onboarding isn't finished.</p>
-    <p>Please contact the platform administrator so they can complete your profile setup and give you full access.</p>
+    <p class="missing-title">To finish setting up your account, we still need:</p>
+    <ul class="missing-list">
+      <li>The membership plan assigned to your account</li>
+      <li>Your full name</li>
+      <li>Your address</li>
+      <li>Your birth date (if applicable)</li>
+    </ul>
+    <p>Please contact the platform administrator and share the information above so they can complete your profile setup and give you full access.</p>
     <p><a href="mailto:support@the-whales.com">Contact support</a></p>
     <p><a href="{% url 'accounts:logout' %}">Log out</a></p>
   </main>


### PR DESCRIPTION
## Summary
- detail the specific membership and personal data that is still required on the English missing profile screen
- add the same explanation and styling to the Arabic version so both languages communicate the required data

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d3298f9dd0832c831b784c1957dc60