### PR TITLE
Adjust course media upload paths

### DIFF
--- a/courses/migrations/0004_alter_course_image_and_more.py
+++ b/courses/migrations/0004_alter_course_image_and_more.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('courses', '0003_viewlecture_user_viewcourse_course_viewcourse_user_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='course',
+            name='image',
+            field=models.ImageField(upload_to='courses/images/'),
+        ),
+        migrations.AlterField(
+            model_name='lecture',
+            name='image',
+            field=models.ImageField(upload_to='courses/images/'),
+        ),
+        migrations.AlterField(
+            model_name='lecture',
+            name='video',
+            field=models.FileField(upload_to='courses/videos/'),
+        ),
+    ]

--- a/courses/models.py
+++ b/courses/models.py
@@ -10,7 +10,7 @@ from users.models import CustomUser
 #courses image title rate 
 class Course(models.Model):
     member_ship = models.ForeignKey(MemberShip,on_delete=models.CASCADE)
-    image = models.ImageField(upload_to='static/course/image')
+    image = models.ImageField(upload_to='courses/images/')
     title = models.CharField(max_length=100)
     number=models.IntegerField(default=1)
     rate = models.IntegerField(default=0)
@@ -26,9 +26,9 @@ class Course(models.Model):
 class Lecture(models.Model):
     course = models.ForeignKey(Course,on_delete=models.CASCADE)
     title = models.CharField(max_length=100)
-    image = models.ImageField(upload_to='static/course/image')
+    image = models.ImageField(upload_to='courses/images/')
     description = models.TextField(null=True , blank=True)
-    video = models.FileField(upload_to='static/course/video')
+    video = models.FileField(upload_to='courses/videos/')
     number = models.IntegerField(default=0)
     rate = models.IntegerField(default=0)
     

--- a/marketing/migrations/0003_alter_marketing_course_image_and_more.py
+++ b/marketing/migrations/0003_alter_marketing_course_image_and_more.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('marketing', '0002_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='marketing_course',
+            name='image',
+            field=models.ImageField(upload_to='courses/images/'),
+        ),
+        migrations.AlterField(
+            model_name='marketing_lecture',
+            name='image',
+            field=models.ImageField(upload_to='courses/images/'),
+        ),
+        migrations.AlterField(
+            model_name='marketing_lecture',
+            name='video',
+            field=models.FileField(upload_to='courses/videos/'),
+        ),
+    ]

--- a/marketing/models.py
+++ b/marketing/models.py
@@ -9,7 +9,7 @@ from users.models import CustomUser
 
 #courses image title rate 
 class Marketing_Course(models.Model):
-    image = models.ImageField(upload_to='static/course/image')
+    image = models.ImageField(upload_to='courses/images/')
     title = models.CharField(max_length=100)
     rate = models.IntegerField(default=0)
     
@@ -24,9 +24,9 @@ class Marketing_Course(models.Model):
 class Marketing_Lecture(models.Model):
     course = models.ForeignKey(Marketing_Course,on_delete=models.CASCADE)
     title = models.CharField(max_length=100)
-    image = models.ImageField(upload_to='static/course/image')
+    image = models.ImageField(upload_to='courses/images/')
     description = models.TextField(null=True,blank=True)
-    video = models.FileField(upload_to='static/course/video')
+    video = models.FileField(upload_to='courses/videos/')
     number = models.IntegerField(default=0)
     rate = models.IntegerField(default=0)
     def __str__(self):


### PR DESCRIPTION
## Summary
- store course and lecture uploads under a media-relative `courses/` folder instead of `static/course`
- add migrations updating the upload destinations for courses and marketing content

## Testing
- `pip install -r requirements.txt` *(fails: proxy blocks outbound connections)*

------
https://chatgpt.com/codex/tasks/task_e_68d330ee8b20832c88ed3d147e1d1bd9