### PR TITLE
Handle missing user profiles in course views

### DIFF
--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -1,0 +1,68 @@
+"""Utility helpers for working with user profiles."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Optional, Tuple
+
+from django.shortcuts import render
+
+from .models import Profile
+
+
+def _build_admin_placeholder_profile(user):
+    """Create a lightweight profile-like object for staff users without profiles."""
+
+    membership_placeholder = SimpleNamespace(name="Not assigned", price=0)
+
+    placeholder = SimpleNamespace(
+        user=user,
+        membership=membership_placeholder,
+        name=getattr(user, "get_full_name", lambda: "")()
+        or getattr(user, "username", "")
+        or getattr(user, "email", ""),
+        address="",
+        birth_date="",
+        coin=0,
+        image=None,
+        price=0,
+        marketing_avilable=False,
+        rank=0,
+        number=0,
+        is_placeholder=True,
+    )
+
+    return placeholder
+
+
+def get_profile_or_missing_response(request, language: str = "en") -> Tuple[Optional[Profile], Optional[object]]:
+    """Return the logged-in user's profile or a fallback response if it is missing.
+
+    The helper mirrors the logic previously used in multiple view functions:
+
+    * Authenticated users with a completed profile get their profile instance.
+    * Staff and superusers without a profile receive a lightweight placeholder so
+      they can continue navigating the dashboard.
+    * Regular users without a profile are shown a friendly "profile missing"
+      page in their preferred language instead of a server error.
+    """
+
+    user = getattr(request, "user", None)
+    if not getattr(user, "is_authenticated", False):
+        return None, None
+
+    profile = (
+        Profile.objects.select_related("membership")
+        .filter(user=user)
+        .first()
+    )
+    if profile is not None:
+        profile.is_placeholder = False
+        return profile, None
+
+    if getattr(user, "is_superuser", False) or getattr(user, "is_staff", False):
+        return _build_admin_placeholder_profile(user), None
+
+    template_name = "profile_missing.html" if language != "ar" else "ar/profile_missing.html"
+    return None, render(request, template_name, status=404)
+

--- a/home/views.py
+++ b/home/views.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 from django.shortcuts import render, redirect
 # import login_required
 from django.contrib.auth.decorators import login_required
@@ -7,59 +5,17 @@ from users.models import CustomUser
 
 # Create your views here.
 #import profile from accounts
-from accounts.models import Profile
+from accounts.utils import get_profile_or_missing_response
 
 
 from django.core.mail import send_mail
 from django.contrib import messages
 from django.conf import settings
 
-#helper to get profile or render missing profile page
-def _build_admin_placeholder_profile(user):
-    """Create a lightweight profile-like object for admin users without profiles."""
-
-    membership_placeholder = SimpleNamespace(name="Not assigned", price=0)
-
-    return SimpleNamespace(
-        user=user,
-        membership=membership_placeholder,
-        name=getattr(user, "get_full_name", lambda: "")() or getattr(user, "username", ""),
-        address="",
-        birth_date="",
-        coin=0,
-        image=None,
-        price=0,
-        marketing_avilable=False,
-        rank=0,
-        number=0,
-    )
-
-
-def _get_profile_or_missing_response(request, language="en"):
-    """Return the logged-in user's profile or a fallback response if it is missing."""
-    user = getattr(request, "user", None)
-    if not getattr(user, "is_authenticated", False):
-        return None, None
-
-    # Allow admin users to continue even if their profiles are incomplete.
-    if getattr(user, "is_superuser", False) or getattr(user, "is_staff", False):
-        profile = Profile.objects.select_related("membership").filter(user=user).first()
-        if profile:
-            return profile, None
-        return _build_admin_placeholder_profile(user), None
-
-    try:
-        profile = Profile.objects.select_related("membership").get(user=user)
-        return profile, None
-    except Profile.DoesNotExist:
-        template_name = "profile_missing.html" if language != "ar" else "ar/profile_missing.html"
-        return None, render(request, template_name, status=404)
-
-
 #home
 @login_required
 def home(request):
-    user_profile, missing_response = _get_profile_or_missing_response(request, language="en")
+    user_profile, missing_response = get_profile_or_missing_response(request, language="en")
     if missing_response:
         return missing_response
 
@@ -73,7 +29,7 @@ def home(request):
 
 @login_required
 def home_ar(request):
-    user_profile, missing_response = _get_profile_or_missing_response(request, language="ar")
+    user_profile, missing_response = get_profile_or_missing_response(request, language="ar")
     if missing_response:
         return missing_response
 
@@ -159,7 +115,7 @@ def send_emails_ar(request):
 @login_required
 def error_404_view(request,exception):
     language = "ar" if request.path.startswith("/ar/") else "en"
-    user_profile, missing_response = _get_profile_or_missing_response(request, language=language)
+    user_profile, missing_response = get_profile_or_missing_response(request, language=language)
     if missing_response:
         return missing_response
 
@@ -174,7 +130,7 @@ def error_404_view(request,exception):
 @login_required
 def error_500_view(request):
     language = "ar" if request.path.startswith("/ar/") else "en"
-    user_profile, missing_response = _get_profile_or_missing_response(request, language=language)
+    user_profile, missing_response = get_profile_or_missing_response(request, language=language)
     if missing_response:
         return missing_response
 


### PR DESCRIPTION
## Summary
- add a reusable helper that returns the current profile or a friendly "profile missing" response
- switch the home and course views to use the helper so users without profiles no longer trigger errors
- streamline lecture loops while preserving duration calculation and viewed flags

## Testing
- python manage.py test *(fails: Django not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d331e5d294832c95d2d43048b78073