### PR TITLE
Redirect Arabic disclaimer refusal to home

### DIFF
--- a/home/templates/ar/base.html
+++ b/home/templates/ar/base.html
@@ -302,8 +302,8 @@
       الدورات على هذا الموقع للأغراض التعليمية فقط ولا ينبغي اعتبارها نصيحة مالية. التداول نشاط عالي المخاطر ويجب عليك دائمًا إجراء البحث الخاص بك قبل اتخاذ أي قرارات استثمارية. نحن لسنا مسؤولين عن أي خسائر قد تحدث لك نتيجة لأنشطة التداول الخاصة بك.
       بالموافقة على هذه الشروط ، فإنك تقر بأنك قد قرأت وفهمت إخلاء المسؤولية هذا وأنك وحدك المسؤول عن أي قرارات استثمارية تتخذها.</div>
      <div class="modal-footer">
-       <a href="{% url 'courses:courses_category_ar' %}" id="" class="btn btn-success">اوافق</a>
-       <a href="#"  id="" class="btn btn-danger">ارفض</a>
+      <a href="{% url 'courses:courses_category_ar' %}" id="" class="btn btn-success">اوافق</a>
+      <a href="{% url 'home:home_ar' %}"  id="" class="btn btn-danger">ارفض</a>
      </div>
    </div>
  </div>


### PR DESCRIPTION
## Summary
- update the Arabic base template so the disclaimer refusal button redirects to the Arabic homepage

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68d3c78b9c18832c978f3ca81a7782fd