### PR TITLE
Handle missing profiles in contact views

### DIFF
--- a/contact/views.py
+++ b/contact/views.py
@@ -1,106 +1,106 @@
-from django.shortcuts import render
-from django.contrib.auth.decorators import login_required
-#get customuser,profile
-from users.models import CustomUser
-from accounts.models import Profile
-#get contact
-from .models import Contact
-#import message
 from django.contrib import messages
-#import redirct
-from django.shortcuts import redirect
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import redirect, render
+
+from accounts.models import Profile
+from users.models import CustomUser
+
+from .models import Contact
+
+
+def _resolve_profiles(user):
+    """Return profile information for the current user and their creator."""
+
+    custom_user = (
+        CustomUser.objects.select_related("create_by")
+        .only("email", "ended_at", "create_by")
+        .get(id=user.id)
+    )
+
+    my_profile = Profile.objects.select_related("user").filter(user=user).first()
+
+    created_by_profile = None
+    created_by_name = ""
+
+    if not user.is_superuser and custom_user.create_by:
+        created_by_profile = Profile.objects.filter(user=custom_user.create_by).first()
+        if created_by_profile:
+            created_by_name = created_by_profile.name
+        else:
+            created_by_name = custom_user.create_by.email
+    elif my_profile:
+        created_by_profile = my_profile
+        created_by_name = my_profile.name
+
+    if not created_by_name:
+        created_by_name = my_profile.name if my_profile else custom_user.email
+
+    return my_profile, custom_user, created_by_profile, created_by_name, custom_user.ended_at
+
+
+def _handle_contact(request, *, template_name, success_message, contact_redirect,
+                    profile_redirect, missing_profile_message):
+    """Shared logic for English and Arabic contact pages."""
+
+    my_profile, custom_user, created_by_profile, created_by_name, ended_at = _resolve_profiles(request.user)
+
+    if my_profile is None:
+        messages.error(request, missing_profile_message)
+        return redirect(profile_redirect)
+
+    if request.method == "POST":
+        subject = (request.POST.get("subject") or "").strip()
+        message_body = (request.POST.get("message") or "").strip()
+
+        Contact.objects.create(
+            name=my_profile.name,
+            email=custom_user.email,
+            create_by=created_by_name,
+            ended_at=ended_at,
+            subject=subject,
+            message=message_body,
+        )
+
+        messages.success(request, success_message)
+        return redirect(contact_redirect)
+
+    context = {
+        "profile": my_profile,
+        "my_profile": my_profile,
+        "custom_user": custom_user,
+        "created_by": created_by_profile,
+        "created_by_name": created_by_name,
+        "ended_at": ended_at,
+    }
+
+    return render(request, template_name, context)
+
 
 # Create your views here.
 
-#contact
+
 @login_required
 def contact(request):
-    #send customuser , profile
-    user = request.user
-    my_profile = Profile.objects.get(user=user)
-    #get custom user that create this user
-    custom_user = CustomUser.objects.get(id=user.id)
-    ended_at=custom_user.ended_at
-
-    #get leader profile that create me
-    if not user.is_superuser:
-        created_by = Profile.objects.get(user=custom_user.create_by)
-    else:
-        created_by = my_profile
-        
-        
-    #save send data
-    if request.method == 'POST':
-        #get data from form
-        name = my_profile.name
-        email = custom_user.email
-        create_by = created_by.name
-        ended_at = custom_user.ended_at
-        subject = request.POST.get('subject')
-        message = request.POST.get('message')
-        #save data
-        contact = Contact(name=name,email=email,create_by=create_by,ended_at=ended_at,subject=subject,message=message)
-        contact.save()
-        #send message
-        messages.success(request, 'your message has been sent successfully')
-        #redirct to contact
-        return redirect('contact:contact')
-    
-    #context
-    context = {
-        'profile':my_profile,
-        'my_profile':my_profile,
-        'custom_user':custom_user,
-        'created_by':created_by,
-        'ended_at':ended_at,
-    }
-    return render(request,'contact.html',context)
+    return _handle_contact(
+        request,
+        template_name="contact.html",
+        success_message="your message has been sent successfully",
+        contact_redirect="contact:contact",
+        profile_redirect="accounts:profile",
+        missing_profile_message="Please complete your profile before contacting support.",
+    )
 
 
+# =======================================AR========================================
 
-
-
-#=======================================AR========================================
 
 @login_required
 def contact_ar(request):
-    #send customuser , profile
-    user = request.user
-    my_profile = Profile.objects.get(user=user)
-    #get custom user that create this user
-    custom_user = CustomUser.objects.get(id=user.id)
-    ended_at=custom_user.ended_at
-
-    #get leader profile that create me
-    if not user.is_superuser:
-        created_by = Profile.objects.get(user=custom_user.create_by)
-    else:
-        created_by = my_profile
-        
-        
-    #save send data
-    if request.method == 'POST':
-        #get data from form
-        name = my_profile.name
-        email = custom_user.email
-        create_by = created_by.name
-        ended_at = custom_user.ended_at
-        subject = request.POST.get('subject')
-        message = request.POST.get('message')
-        #save data
-        contact = Contact(name=name,email=email,create_by=create_by,ended_at=ended_at,subject=subject,message=message)
-        contact.save()
-        #send message
-        messages.success(request, 'تم ارسال رسالتك بنجاح')
-        #redirct to contact
-        return redirect('contact:contact_ar')
-    
-    #context
-    context = {
-        'profile':my_profile,
-        'my_profile':my_profile,
-        'custom_user':custom_user,
-        'created_by':created_by,
-        'ended_at':ended_at,
-    }
-    return render(request,'ar/contact.html',context)
+    return _handle_contact(
+        request,
+        template_name="ar/contact.html",
+        success_message="تم ارسال رسالتك بنجاح",
+        contact_redirect="contact:contact_ar",
+        profile_redirect="accounts:profile_ar",
+        missing_profile_message="يرجى استكمال ملفك الشخصي قبل التواصل معنا.",
+    )

--- a/home/templates/ar/contact.html
+++ b/home/templates/ar/contact.html
@@ -54,7 +54,7 @@
                   <div class="col-6">
                     <div>
                       <label for="name" class="form-label">تمت الاضافة بواسطه</label>
-                      <input class="form-control" type="text" id="name" value="{{ created_by.name }}" readonly required>
+                      <input class="form-control" type="text" id="name" value="{{ created_by_name }}" readonly required>
                     </div>
                   </div>
                   <div class="col-6">

--- a/home/templates/contact.html
+++ b/home/templates/contact.html
@@ -55,7 +55,7 @@
                   <div class="col-6">
                     <div>
                       <label for="name" class="form-label">Added By</label>
-                      <input class="form-control" type="text" id="name" value="{{ created_by.name }}" readonly required>
+                      <input class="form-control" type="text" id="name" value="{{ created_by_name }}" readonly required>
                     </div>
                   </div>
                   <div class="col-6">


### PR DESCRIPTION
## Summary
- add shared contact handler that gracefully resolves user and creator profiles
- surface fallback strings for missing creator names in both English and Arabic templates
- redirect users without profiles to the appropriate profile page instead of erroring

## Testing
- python manage.py test contact *(fails: Django missing because dependencies cannot be installed behind the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c6d2bb04832caec0ed624cd8dbf4