### PR TITLE
Handle missing profile images in profile modals

### DIFF
--- a/home/templates/ar/profile.html
+++ b/home/templates/ar/profile.html
@@ -557,7 +557,11 @@
         <div class="modal-body" id="modal-body-content">
         <!---profile image-->
           <div class="profile-container">
+            {% if profile.image %}
             <img src="{{ profile.image.url }}" alt="Profile Image">
+            {% else %}
+            <img src="{% static 'assets/images/user.png' %}" alt="Profile Image">
+            {% endif %}
           </div>
         </div>
         <div class="modal-footer">

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -502,7 +502,11 @@
         <div class="modal-body" id="modal-body-content">
         <!---profile image-->
           <div class="profile-container">
+            {% if profile.image %}
             <img src="{{ profile.image.url }}" alt="Profile Image">
+            {% else %}
+            <img src="{% static 'assets/images/user.png' %}" alt="Profile Image">
+            {% endif %}
           </div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
## Summary
- guard the Arabic profile modal against missing uploaded images by falling back to the default avatar
- mirror the same fallback in the English profile modal so both pages avoid missing-file errors

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d3c924d7c4832ca88c059bdca132be