### PR TITLE
Configure CSRF trusted origins for the-whales.com

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -26,6 +26,10 @@ SECRET_KEY = 'django-insecure-5vf5zjeb9&8x6o+-i4nfk1ux&=%6pd-h4$#d8%a71--g@d=hyq
 DEBUG = True
 # DEBUG = True
 ALLOWED_HOSTS = ['207.180.239.207', 'the-whales.com' , 'tradingwhales.online','93.127.203.33','localhost','127.0.0.1' ]
+
+CSRF_TRUSTED_ORIGINS = [
+    'https://the-whales.com',
+]
 # Application definition
 INSTALLED_APPS = [
     'jazzmin',


### PR DESCRIPTION
## Summary
- add the-whales.com to CSRF trusted origins to allow form submissions from the production domain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907ac2a4634832c893e4d664706e634