### PR TITLE
Allow expired superusers to access dashboard

### DIFF
--- a/accounts/middleware.py
+++ b/accounts/middleware.py
@@ -16,7 +16,7 @@ class MembershipExpirationMiddleware:
         if user is not None and user.is_authenticated:
             ended_at = getattr(user, "ended_at", None)
 
-            if ended_at and ended_at < timezone.now():
+            if not user.is_superuser and ended_at and ended_at < timezone.now():
                 logout(request)
                 messages.error(
                     request,

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,3 +1,37 @@
-from django.test import TestCase
+from datetime import timedelta
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+
+class SuperuserExpiredMembershipAccessTests(TestCase):
+    def setUp(self):
+        self.User = get_user_model()
+        self.password = "StrongPass123!"
+        self.superuser = self.User.objects.create_superuser(
+            email="admin@example.com",
+            phone="1000000000",
+            password=self.password,
+        )
+        self.superuser.ended_at = timezone.now() - timedelta(days=1)
+        self.superuser.save(update_fields=["ended_at"])
+
+    def test_expired_superuser_can_log_in(self):
+        response = self.client.post(
+            reverse("accounts:login"),
+            {"username": self.superuser.email, "password": self.password},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("home:home_ar"))
+        self.assertEqual(int(self.client.session["_auth_user_id"]), self.superuser.id)
+
+    def test_expired_superuser_is_not_logged_out_by_membership_middleware(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(reverse("accounts:profile"))
+
+        self.assertNotEqual(response.status_code, 302)
+        self.assertEqual(int(self.client.session["_auth_user_id"]), self.superuser.id)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -136,7 +136,7 @@ def log_in(request):
             messages.error(request, 'Dear Trader, we would like to inform you that your educational period on the Whales Trading website has ended. If you wish to renew your subscription and continue your educational journey with us, please contact the responsible person to review the new plans. Thank you for choosing Whales Trading. We look forward to continuing to support you and providing you with the best educational experience. Best regards, The Whales Trading Team."')
             return render(request,'index.html')
 
-        if user.ended_at and user.ended_at < timezone.now():
+        if not user.is_superuser and user.ended_at and user.ended_at < timezone.now():
             messages.error(request, 'Your plan has ended. Please contact the administrators to renew your plan.')
             return render(request,'index.html')
 


### PR DESCRIPTION
### Motivation
- Superuser accounts were being blocked from accessing the dashboard when their `ended_at` date was in the past, which prevents administrators from managing the site when plans expire.
- The intent is to exempt administrative users from membership expiration checks so they can always access admin/profile pages.

### Description
- Update login flow in `accounts/views.py` to skip the plan-expired rejection for users with `is_superuser` set (`if not user.is_superuser and user.ended_at ...`).
- Update `MembershipExpirationMiddleware` in `accounts/middleware.py` to avoid logging out superusers when `ended_at` is past (`if not user.is_superuser and ended_at ...`).
- Add regression tests in `accounts/tests.py` to assert that an expired superuser can log in and is not logged out by the middleware.

### Testing
- Compiled modified files with `python -m py_compile accounts/views.py accounts/middleware.py accounts/tests.py` which succeeded.
- Ran `git diff --check` and basic repository checks which reported no issues, and committed the changes as a single change set.
- Attempted to run `python manage.py test accounts -v 2` but the test execution was blocked because Django is not available in the current environment (local `.venv` could not be used to run tests here).
- الخطوات اللى عملتها بعد الانتهاء: عدّلت شروط الدخول فى `accounts/views.py`, عدّلت middleware فى `accounts/middleware.py`, اضفت اختبارات فى `accounts/tests.py`, عملت `py_compile` للتأكد من صحة البايثون، وحاولت تشغيل اختبارات الوحدة لكن بيئة Django لم تكن مُثبتة، ثم قمت بعمل commit للتغييرات.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41983b10dc832c9eb9e614acdb4a83)